### PR TITLE
Adding an optional annotation 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # build stage
 FROM golang:latest AS build-env
-RUN go get github.com/golang/dep/cmd/dep && go get -d github.com/GoogleCloudPlatform/k8s-node-termination-handler
+RUN go get github.com/golang/dep/cmd/dep 
+RUN go get -d github.com/GoogleCloudPlatform/k8s-node-termination-handler || true
 WORKDIR /go/src/github.com/GoogleCloudPlatform/k8s-node-termination-handler
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -tags netgo -o node-termination-handler
 


### PR DESCRIPTION
To work around GKE security requirements, annotations will be used instead of taints.
The GCP controller manager will convert annotations into taints via https://github.com/kubernetes/cloud-provider-gcp/pull/50

cc @mindprince 
