### PR TITLE
Rebase to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # build stage
 FROM golang:latest AS build-env
-RUN go get github.com/golang/dep/cmd/dep 
+RUN go get github.com/golang/dep/cmd/dep
 RUN go get -d github.com/GoogleCloudPlatform/k8s-node-termination-handler || true
 WORKDIR /go/src/github.com/GoogleCloudPlatform/k8s-node-termination-handler
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -tags netgo -o node-termination-handler
 
 # final stage
-FROM alpine
+FROM gcr.io/distroless/static:latest
 WORKDIR /app
 COPY --from=build-env /go/src/github.com/GoogleCloudPlatform/k8s-node-termination-handler/node-termination-handler /app/
-ENTRYPOINT ./node-termination-handler
+ENTRYPOINT ["./node-termination-handler"]


### PR DESCRIPTION
This is part of the effort in kep kubernetes/enhancements#900
Due to CVE concerns, we'd like to rebase the image from alpine to distroless.
This image doesn't have extra dependencies, so we should be good.

Also fixed some linter issues.