### PR TITLE
Adding get verb for pod API to RBAC manifest to avoid permissions error

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -40,7 +40,7 @@ rules:
   # Allow Node Termination Handler to list and delete pods (for draining nodes)
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "delete"]
+  verbs: ["get", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The following commit introduces the use of a `Pods.Get()` call: https://github.com/GoogleCloudPlatform/k8s-node-termination-handler/commit/61196ecbc5a9bf474f948b18d4df1b56a54f5373

However, the ClusterRole does not have the proper permission, so this error occurs when a pod is attempted to be terminated:

```
Pod "default"/"redacted" did not get deleted within grace period 824639238136 seconds: pods "redacted" is forbidden: User "system:serviceaccount:kube-system:node-termination-handler" cannot get resource "pods" in API group "" in the namespace "default"
```

This can be fixed by adding that verb to the list.