### PR TITLE
Add `hostNetwork: true` for compat with Workload Identity

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -30,6 +30,8 @@ spec:
       labels:
         name: node-termination-handler
     spec:
+      # Necessary to hit the node's metadata server when using Workload Identity
+      hostNetwork: true
       # Necessary to reboot node
       hostPID: true
       serviceAccountName: node-termination-handler


### PR DESCRIPTION
The daemonset relies on reading the preemption endpoint of the node's metadata server.

When using GKE Workload Identity, the daemonset is instead talking to gke-metadata-server, which doesn't expose the preemption endpoint.

This can be bypassed by running the daemonset in the host network namespace, so that it still talks to the node metadata server.