### PR TITLE
Add grace period value to delete pod logs

### DIFF
--- a/termination/eviction.go
+++ b/termination/eviction.go
@@ -96,7 +96,7 @@ func (p *podEvictionHandler) deletePods(pods []v1.Pod, deleteOptions *metav1.Del
 	for _, pod := range pods {
 		p.recorder.Eventf(&pod, v1.EventTypeWarning, eventReason, "Node %q is about to be terminated. Evicting pod prior to node termination.", p.node)
 		// Delete the pod with the specified timeout.
-		glog.V(4).Infof("About to delete pod %q in namespace %q", pod.Name, pod.Namespace)
+		glog.V(4).Infof("About to delete pod %q in namespace %q within grace period %d seconds", pod.Name, pod.Namespace, *deleteOptions.GracePeriodSeconds)
 		if err := p.client.Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err != nil {
 			glog.V(2).Infof("Failed to delete pod %q in namespace %q - %v", pod.Name, pod.Namespace, err)
 			return err
@@ -105,7 +105,7 @@ func (p *podEvictionHandler) deletePods(pods []v1.Pod, deleteOptions *metav1.Del
 	// wait for pods to be actually deleted since deletion is asynchronous & pods have a deletion grace period to exit gracefully.
 	for _, pod := range pods {
 		if err := p.waitForPodNotFound(pod.Name, pod.Namespace, time.Duration(*deleteOptions.GracePeriodSeconds)*time.Second); err != nil {
-			glog.Errorf("Pod %q/%q did not get deleted within grace period %d seconds: %v", pod.Namespace, pod.Name, deleteOptions.GracePeriodSeconds, err)
+			glog.Errorf("Pod %q/%q did not get deleted within grace period %d seconds: %v", pod.Namespace, pod.Name, *deleteOptions.GracePeriodSeconds, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
I thought it would be good to include the value of the grace period in the existing execution log so that we can see the value actually used for the deletion request. Also, the grace period in the existing error log has a pointer address that needs to be modified.